### PR TITLE
refactor: remove bun:sqlite dependency from source code

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "kiro-memory": "./plugin/dist/cli/contextkit.js"
   },
   "engines": {
-    "node": ">=18.0.0",
-    "bun": ">=1.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "dev": "npm run build-and-sync",

--- a/scripts/build-plugin.js
+++ b/scripts/build-plugin.js
@@ -1,7 +1,8 @@
 /**
  * Kiro Memory build configuration
  *
- * Usa lo shim bun:sqlite → better-sqlite3 per compatibilità Node.js puro.
+ * Uses better-sqlite3 as the default SQLite provider.
+ * No Bun runtime required — works on any Node.js >= 18.
  */
 
 import * as esbuild from 'esbuild';
@@ -14,30 +15,19 @@ const SRC_DIR = join(ROOT_DIR, 'src');
 const PLUGIN_DIR = join(ROOT_DIR, 'plugin');
 const DIST_DIR = join(PLUGIN_DIR, 'dist');
 
-// Plugin esbuild: sostituisce 'bun:sqlite' con lo shim better-sqlite3
-const bunSqliteShimPlugin = {
-  name: 'bun-sqlite-shim',
-  setup(build) {
-    build.onResolve({ filter: /^bun:sqlite$/ }, () => ({
-      path: join(SRC_DIR, 'shims', 'bun-sqlite.ts'),
-    }));
-  }
-};
-
-// Banner per abilitare require() in contesto ESM (necessario per moduli CJS nativi come better-sqlite3)
+// Banner to enable require() in ESM context (needed for native CJS modules like better-sqlite3)
 const esmRequireBanner = {
   js: `import { createRequire } from 'module';const require = createRequire(import.meta.url);`
 };
 
-// Opzioni comuni per tutti i build Node.js
+// Common options for all Node.js builds
 const nodeCommon = {
   bundle: true,
   platform: 'node',
   target: 'node18',
   format: 'esm',
   banner: esmRequireBanner,
-  plugins: [bunSqliteShimPlugin],
-  // CJS nativi e optional deps, caricati a runtime
+  // Native CJS modules and optional deps, loaded at runtime
   external: ['better-sqlite3', 'fastembed', '@huggingface/transformers', 'onnxruntime-node', '@anush008/tokenizers']
 };
 

--- a/src/cli/cli-utils.ts
+++ b/src/cli/cli-utils.ts
@@ -481,7 +481,7 @@ export function formatImportResult(result: {
  * Verifica se un indice FTS5 è danneggiato eseguendo una query di integrità.
  * Ritorna true se l'indice è integro.
  */
-export function checkFtsIntegrity(db: import('bun:sqlite').Database): boolean {
+export function checkFtsIntegrity(db: import('../db/types.js').Database): boolean {
   try {
     // fts5 integrity check: eseguire insert fittizio su tabella shadow causa errore se corrotta
     db.query("INSERT INTO observations_fts(observations_fts) VALUES('integrity-check')").run();
@@ -495,7 +495,7 @@ export function checkFtsIntegrity(db: import('bun:sqlite').Database): boolean {
  * Ricostruisce l'indice FTS5 per le observations.
  * Ritorna true se l'operazione è riuscita.
  */
-export function rebuildFtsIndex(db: import('bun:sqlite').Database): boolean {
+export function rebuildFtsIndex(db: import('../db/types.js').Database): boolean {
   try {
     db.run("INSERT INTO observations_fts(observations_fts) VALUES('rebuild')");
     return true;
@@ -508,7 +508,7 @@ export function rebuildFtsIndex(db: import('bun:sqlite').Database): boolean {
  * Rimuove gli embeddings orfani (observation_id non più presente).
  * Ritorna il numero di record rimossi.
  */
-export function removeOrphanedEmbeddings(db: import('bun:sqlite').Database): number {
+export function removeOrphanedEmbeddings(db: import('../db/types.js').Database): number {
   try {
     const result = db.run(
       `DELETE FROM observation_embeddings
@@ -524,7 +524,7 @@ export function removeOrphanedEmbeddings(db: import('bun:sqlite').Database): num
  * Esegue VACUUM sul database per recuperare spazio.
  * Ritorna true se l'operazione è riuscita.
  */
-export function vacuumDatabase(db: import('bun:sqlite').Database): boolean {
+export function vacuumDatabase(db: import('../db/types.js').Database): boolean {
   try {
     db.run('VACUUM');
     return true;

--- a/src/db/better-sqlite3-adapter.ts
+++ b/src/db/better-sqlite3-adapter.ts
@@ -1,0 +1,135 @@
+/**
+ * SQLite adapter using better-sqlite3
+ *
+ * Default database provider for Kiro Memory.
+ * Works on any Node.js >= 18 without requiring Bun.
+ *
+ * Implements the Database interface defined in ./types.ts.
+ */
+
+import BetterSqlite3 from 'better-sqlite3';
+import type { Database as IDatabase, Statement, RunResult } from './types.js';
+
+/**
+ * SQLite database connection backed by better-sqlite3.
+ */
+export class Database {
+  private _db: BetterSqlite3.Database;
+  private _stmtCache: Map<string, PreparedStatement> = new Map();
+
+  constructor(path: string, options?: { create?: boolean; readwrite?: boolean }) {
+    this._db = new BetterSqlite3(path, {
+      // better-sqlite3 creates the file by default ('create' not needed)
+      readonly: options?.readwrite === false ? true : false
+    });
+  }
+
+  /**
+   * Execute a SQL query without results.
+   * PRAGMA statements are handled via better-sqlite3's native pragma() method.
+   */
+  run(sql: string, params?: any[]): { lastInsertRowid: number | bigint; changes: number } {
+    // better-sqlite3 handles PRAGMA via .pragma(), not .prepare().run()
+    const trimmed = sql.trim();
+    if (/^PRAGMA\s+/i.test(trimmed)) {
+      // Extract "key = value" from "PRAGMA key = value"
+      const pragmaBody = trimmed.replace(/^PRAGMA\s+/i, '').replace(/;$/, '');
+      this._db.pragma(pragmaBody);
+      return { lastInsertRowid: 0, changes: 0 };
+    }
+    const stmt = this._db.prepare(sql);
+    const result = params ? stmt.run(...params) : stmt.run();
+    return result;
+  }
+
+  /**
+   * Prepare a query and return a cached prepared statement.
+   * Returns a cached prepared statement for repeated queries.
+   */
+  query(sql: string): PreparedStatement {
+    let cached = this._stmtCache.get(sql);
+    if (!cached) {
+      cached = new PreparedStatement(this._db, sql);
+      this._stmtCache.set(sql, cached);
+    }
+    return cached;
+  }
+
+  /**
+   * Create a transaction
+   */
+  transaction<T>(fn: (...args: any[]) => T): (...args: any[]) => T {
+    return this._db.transaction(fn) as any;
+  }
+
+  /**
+   * Close the connection
+   */
+  close(): void {
+    this._stmtCache.clear();
+    this._db.close();
+  }
+}
+
+/**
+ * Prepared statement wrapper.
+ * Adapts better-sqlite3's parameter format and caches the compiled statement.
+ */
+class PreparedStatement implements Statement {
+  private _stmt: BetterSqlite3.Statement;
+
+  constructor(db: BetterSqlite3.Database, sql: string) {
+    this._stmt = db.prepare(sql);
+  }
+
+  /**
+   * Adapt named parameters from $-prefixed format to plain keys.
+   * Input:  { $todayStart: 123 }
+   * Output: { todayStart: 123 }
+   * (better-sqlite3 expects keys without the $ prefix)
+   */
+  private _adaptParams(params: any[]): any[] {
+    if (params.length !== 1 || typeof params[0] !== 'object' || params[0] === null || Array.isArray(params[0])) {
+      return params;
+    }
+    const obj = params[0];
+    const keys = Object.keys(obj);
+    if (keys.length === 0) return params;
+    // Keys without $/@/: prefix are already compatible
+    if (!keys[0].startsWith('$') && !keys[0].startsWith('@') && !keys[0].startsWith(':')) {
+      return params;
+    }
+    // Strip the prefix from keys
+    const adapted: Record<string, any> = {};
+    for (const key of keys) {
+      adapted[key.slice(1)] = obj[key];
+    }
+    return [adapted];
+  }
+
+  /**
+   * Returns all rows
+   */
+  all(...params: any[]): any[] {
+    if (params.length === 0) return this._stmt.all();
+    return this._stmt.all(...this._adaptParams(params));
+  }
+
+  /**
+   * Returns the first row or null
+   */
+  get(...params: any[]): any {
+    if (params.length === 0) return this._stmt.get();
+    return this._stmt.get(...this._adaptParams(params));
+  }
+
+  /**
+   * Execute without results
+   */
+  run(...params: any[]): { lastInsertRowid: number | bigint; changes: number } {
+    if (params.length === 0) return this._stmt.run();
+    return this._stmt.run(...this._adaptParams(params));
+  }
+}
+
+

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Database adapter for Kiro Memory
+ *
+ * Default implementation: better-sqlite3 (works on any Node.js ≥ 18).
+ * No Bun runtime required.
+ *
+ * Re-exports the Database class and adapter types so the rest of the
+ * codebase imports from '@db' (mapped via tsconfig paths) or '../db'.
+ */
+
+export type { Database as DatabaseInterface, Statement, RunResult } from './types.js';
+export { Database } from './better-sqlite3-adapter.js';

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Database adapter types for Kiro Memory
+ *
+ * Defines the contract for SQLite database access.
+ * The default implementation uses better-sqlite3 (Node.js).
+ * Alternative providers (e.g. bun:sqlite) can implement these interfaces.
+ */
+
+/** Result of a write operation (INSERT, UPDATE, DELETE). */
+export interface RunResult {
+  lastInsertRowid: number | bigint;
+  changes: number;
+}
+
+/** Prepared statement with query/execute methods. */
+export interface Statement {
+  all(...params: any[]): any[];
+  get(...params: any[]): any;
+  run(...params: any[]): RunResult;
+}
+
+/** SQLite database connection. */
+export interface Database {
+  run(sql: string, params?: any[]): RunResult;
+  query(sql: string): Statement;
+  transaction<T>(fn: (...args: any[]) => T): (...args: any[]) => T;
+  close(): void;
+}

--- a/src/services/analytics/AnomalyDetector.ts
+++ b/src/services/analytics/AnomalyDetector.ts
@@ -1,4 +1,4 @@
-import type { Database } from 'bun:sqlite';
+import type { Database } from '../../db/types.js';
 import { logger } from '../../utils/logger.js';
 
 /**

--- a/src/services/jobs/JobQueue.ts
+++ b/src/services/jobs/JobQueue.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 import { logger } from '../../utils/logger.js';
 
 // Job status lifecycle: pending → running → completed | dead

--- a/src/services/jobs/handlers.ts
+++ b/src/services/jobs/handlers.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 import type { IJobHandler } from './JobQueue.js';
 import { consolidateObservations } from '../sqlite/Observations.js';
 import { logger } from '../../utils/logger.js';

--- a/src/services/search/HybridSearch.ts
+++ b/src/services/search/HybridSearch.ts
@@ -20,7 +20,7 @@ import {
   knowledgeTypeBoost,
   SEARCH_WEIGHTS
 } from './ScoringEngine.js';
-import type { Database } from 'bun:sqlite';
+import type { Database } from '../../db/types.js';
 import type { ScoringWeights } from '../../types/worker-types.js';
 import { logger } from '../../utils/logger.js';
 

--- a/src/services/search/VectorSearch.ts
+++ b/src/services/search/VectorSearch.ts
@@ -10,7 +10,7 @@
  * - Buffer pooling to reduce GC allocations
  */
 
-import type { Database } from 'bun:sqlite';
+import type { Database } from '../../db/types.js';
 import { getEmbeddingService } from './EmbeddingService.js';
 import { logger } from '../../utils/logger.js';
 

--- a/src/services/sqlite/Analytics.ts
+++ b/src/services/sqlite/Analytics.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 
 /**
  * Analytics module for Kiro Memory.

--- a/src/services/sqlite/Backup.ts
+++ b/src/services/sqlite/Backup.ts
@@ -21,7 +21,7 @@ import {
   writeFileSync,
 } from 'fs';
 import { join, basename } from 'path';
-import type { Database } from 'bun:sqlite';
+import type { Database } from '../../db/types.js';
 import { logger } from '../../utils/logger.js';
 
 // ─── Tipi pubblici ───

--- a/src/services/sqlite/Checkpoints.ts
+++ b/src/services/sqlite/Checkpoints.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 import type { DBCheckpoint } from '../../types/worker-types.js';
 
 /**

--- a/src/services/sqlite/Database.ts
+++ b/src/services/sqlite/Database.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 import { DATA_DIR, DB_PATH, ensureDir } from '../../shared/paths.js';
 import { logger } from '../../utils/logger.js';
 
@@ -17,7 +17,7 @@ export interface Migration {
 /**
  * KiroMemoryDatabase - Main entry point for the sqlite module
  *
- * Sets up bun:sqlite with optimized settings and runs all migrations.
+ * Sets up SQLite with optimized settings and runs all migrations.
  *
  * Usage:
  *   const db = new KiroMemoryDatabase();  // uses default DB_PATH
@@ -467,5 +467,5 @@ class MigrationRunner {
   }
 }
 
-// Re-export bun:sqlite Database type
+// Re-export Database type from adapter
 export { Database };

--- a/src/services/sqlite/GithubLinks.ts
+++ b/src/services/sqlite/GithubLinks.ts
@@ -5,7 +5,7 @@
  * (stessa convenzione degli altri moduli sqlite del progetto).
  */
 
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 
 // ── Tipi ──
 

--- a/src/services/sqlite/ImportExport.ts
+++ b/src/services/sqlite/ImportExport.ts
@@ -8,7 +8,7 @@
  * - Dry-run mode per import
  */
 
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 import { createHash } from 'crypto';
 
 // ── Versione schema JSONL ──

--- a/src/services/sqlite/Observations.ts
+++ b/src/services/sqlite/Observations.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 import type { Observation } from '../../types/worker-types.js';
 import { redactSecrets } from '../../utils/secrets.js';
 import { categorize } from '../../utils/categorizer.js';

--- a/src/services/sqlite/Prompts.ts
+++ b/src/services/sqlite/Prompts.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 import type { UserPrompt } from '../../types/worker-types.js';
 
 /**

--- a/src/services/sqlite/Reports.ts
+++ b/src/services/sqlite/Reports.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 import type { ReportData } from '../../types/worker-types.js';
 
 /**

--- a/src/services/sqlite/Retention.ts
+++ b/src/services/sqlite/Retention.ts
@@ -13,7 +13,7 @@
  *     sempre esentate, indipendentemente dalla configurazione.
  */
 
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 import { KNOWLEDGE_TYPES } from '../../types/worker-types.js';
 
 // ── Tipi pubblici ──────────────────────────────────────────────────────────────

--- a/src/services/sqlite/Search.ts
+++ b/src/services/sqlite/Search.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 import { existsSync, statSync } from 'fs';
 import type { Observation, Summary, SearchFilters, TimelineEntry } from '../../types/worker-types.js';
 

--- a/src/services/sqlite/Sessions.ts
+++ b/src/services/sqlite/Sessions.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 import type { DBSession } from '../../types/worker-types.js';
 
 /**

--- a/src/services/sqlite/Summaries.ts
+++ b/src/services/sqlite/Summaries.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import { Database } from '../../db/index.js';
 import type { Summary } from '../../types/worker-types.js';
 
 /**


### PR DESCRIPTION
## Summary

Replaces all `import { Database } from 'bun:sqlite'` across the source code with a proper database adapter layer using `better-sqlite3` directly.

## What changed

- **New `src/db/` module** with:
  - `types.ts` — `Database`, `Statement`, `RunResult` interfaces
  - `better-sqlite3-adapter.ts` — Default implementation (moved from `src/shims/bun-sqlite.ts`)
  - `index.ts` — Re-exports for easy import

- **18 source files** updated: `import { Database } from 'bun:sqlite'` → `import { Database } from '../../db/index.js'`

- **4 CLI inline type imports** updated: `import('bun:sqlite').Database` → `import('../db/types.js').Database`

- **Build system** simplified: removed the `bunSqliteShimPlugin` esbuild plugin (no longer needed since source already imports better-sqlite3)

- **package.json**: removed `bun` from `engines` — only Node.js >= 18 is required

## Why

1. **Perception** — Opening any source file and seeing `from 'bun:sqlite'` makes people think Bun is required. It isn't.
2. **Contributor DX** — Developers can now work on the project with Node.js only
3. **Explicit > implicit** — The npm bundle already used better-sqlite3 via the esbuild shim. This makes it explicit in the source.

## Breaking changes

**None.** The distributed npm bundle already used better-sqlite3 via the esbuild shim plugin. This refactor makes the source match what was already shipped.

## Not in scope (Phase 2)

- Migrating tests from `bun test` to `vitest`
- Removing the legacy `src/shims/bun-sqlite.ts` file
- Updating worker management scripts from `bun` to `node`